### PR TITLE
Fix LightGlue init on systems without CUDA

### DIFF
--- a/slam/core/features_utils.py
+++ b/slam/core/features_utils.py
@@ -21,8 +21,9 @@ def init_feature_pipeline(args):
     Returns (detector, matcher)
     """
     if args.use_lightglue:
-        detector = ALIKED(max_num_keypoints=2048).eval().cuda()
-        matcher  = LightGlue(features='aliked').eval().cuda()
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        detector = ALIKED(max_num_keypoints=2048).eval().to(device)
+        matcher  = LightGlue(features='aliked').eval().to(device)
     else:
         detector = _get_opencv_detector(args.detector)
         matcher  = _get_opencv_matcher(args.matcher, args.detector)


### PR DESCRIPTION
## Summary
- fix LightGlue initialization when CUDA is not available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68535c04eb2c832da969b8ed066c8825