### PR TITLE
Add match confidence filter and keyframe tracking

### DIFF
--- a/slam/core/features_utils.py
+++ b/slam/core/features_utils.py
@@ -98,7 +98,7 @@ def feature_extractor(args, img: np.ndarray, detector):
 
 
 def feature_matcher(args, kp0, kp1, des0, des1, matcher):
-    """Match features between two frames."""
+    """    Match features between two FrameFeatures and return OpenCV-compatible matches."""
     # optionally filter matches from LightGlue by confidence
     if args.use_lightglue:
         # LightGlue matching

--- a/slam/core/features_utils.py
+++ b/slam/core/features_utils.py
@@ -98,10 +98,8 @@ def feature_extractor(args, img: np.ndarray, detector):
 
 
 def feature_matcher(args, kp0, kp1, des0, des1, matcher):
-    """
-    Match features between two FrameFeatures and return OpenCV-compatible matches.
-    """
-    # TODO: add min_conf filtering
+    """Match features between two frames."""
+    # optionally filter matches from LightGlue by confidence
     if args.use_lightglue:
         # LightGlue matching
         # kp0, kp1: List[cv2.KeyPoint]
@@ -118,6 +116,10 @@ def feature_matcher(args, kp0, kp1, des0, des1, matcher):
         })
         raw = rbd(raw)
         matches_raw = raw['matches']
+        conf = raw.get('scores') or raw.get('confidence')
+        if conf is not None:
+            mask = conf > args.min_conf
+            matches_raw = matches_raw[mask]
         # convert index pairs to cv2.DMatch list
         cv_matches = _convert_lg_matches_to_opencv(matches_raw)
         return cv_matches

--- a/slam/monocular/main.py
+++ b/slam/monocular/main.py
@@ -61,6 +61,8 @@ def _build_parser() -> argparse.ArgumentParser:
                    default='orb')
     p.add_argument('--matcher', choices=['bf'], default='bf')
     p.add_argument('--use_lightglue', action='store_true')
+    p.add_argument('--min_conf', type=float, default=0.5,
+                   help='Minimum LightGlue confidence for a match')
     # runtime
     p.add_argument('--fps', type=float, default=10)
     # RANSAC
@@ -260,8 +262,10 @@ def main():
 
                     # coarse rigid alignment of the *new* cloud to the map
                     pts3d_world = world_map.align_points_to_map(pts3d_world, radius=args.merge_radius * 2.0)  # TODO: HYPER PARAMETER CHECK -MAGIC VARIABLE- radius can be loose here
-                    new_ids = world_map.add_points(pts3d_world, cols)
                     frame_no = i + 1
+                    new_ids = world_map.add_points(
+                        pts3d_world, cols, keyframe_idx=frame_no
+                    )
                     for pid, m in zip(new_ids, np.asarray(fresh)[valid]):
                         world_map.points[pid].add_observation(frame_no, m.trainIdx)
 

--- a/slam/monocular/main.py
+++ b/slam/monocular/main.py
@@ -61,7 +61,7 @@ def _build_parser() -> argparse.ArgumentParser:
                    default='orb')
     p.add_argument('--matcher', choices=['bf'], default='bf')
     p.add_argument('--use_lightglue', action='store_true')
-    p.add_argument('--min_conf', type=float, default=0.5,
+    p.add_argument('--min_conf', type=float, default=0.7,
                    help='Minimum LightGlue confidence for a match')
     # runtime
     p.add_argument('--fps', type=float, default=10)

--- a/tests/test_lightglue_vs_manual.py
+++ b/tests/test_lightglue_vs_manual.py
@@ -32,7 +32,8 @@ def test_lightglue_pipeline_matches_manual(synthetic_pair):
     # build a fake args object
     args = SimpleNamespace(use_lightglue=True,
                            detector=None,  # not used for LG
-                           matcher=None)
+                           matcher=None,
+                           min_conf=0.0)
 
     # 1) initialize LightGlue extractor & matcher
     extractor, matcher = init_feature_pipeline(args)


### PR DESCRIPTION
## Summary
- add optional confidence filter to `feature_matcher`
- store the source keyframe index in `MapPoint`
- allow specifying minimum LightGlue confidence via CLI
- propagate keyframe index when adding points
- update tests
------
https://chatgpt.com/codex/tasks/task_e_6860215b6b48832d84d060aa82541152